### PR TITLE
Improve CPU usage for pimoroni/mopidy-pidi#2

### DIFF
--- a/pidi-display-st7789/pidi_display_st7789/__init__.py
+++ b/pidi-display-st7789/pidi_display_st7789/__init__.py
@@ -23,8 +23,8 @@ class DisplayST7789(DisplayPIL):
         self._st7789.begin()
 
     def redraw(self):
-        DisplayPIL.redraw(self)
-        self._st7789.display(self._output_image)
+        if DisplayPIL.redraw(self):
+            self._st7789.display(self._output_image)
 
     def add_args(argparse):
         """Add supplemental arguments for ST7789."""


### PR DESCRIPTION
I found some good opportunities to optmise both `pidi-display-pil` and, as a consequence, `pidi-display-st7789` to avoid drawing calls unless:

1. The volume changes (and thus the bar needs to be redrawn)
2. The "progress" advances enough that it will visually change (determined in pixels)
3. An album art transition is happening
4. The song state has changed (play/pause)