### PR TITLE
Swap play and pause button states?

### DIFF
--- a/pidi-display-pil/pidi_display_pil/__init__.py
+++ b/pidi-display-pil/pidi_display_pil/__init__.py
@@ -214,9 +214,9 @@ class DisplayPIL(Display):
 
         # Overlay control icons
         if self._state == "play":
-            overlay = Image.alpha_composite(overlay, self.controls_play)
-        else:
             overlay = Image.alpha_composite(overlay, self.controls_pause)
+        else:
+            overlay = Image.alpha_composite(overlay, self.controls_play)
 
         # Overlay combined track info onto album art
         image = Image.alpha_composite(art, overlay)


### PR DESCRIPTION
I've been using pirate-audio 3W amp and I thought the play and pause icons are the wrong way around?

- currently: I see the play icon displayed next to the physical button when the music is playing and the pause icon next to the physical button when the music is paused. 

- suggested by change: Is it more normal that the icon would show what would happen if the button was pressed? i.e. play icon would appear next to the button when the music was paused and pause icon would appear next to the button when the music was playing.

This change swaps the icons around. 